### PR TITLE
Update runtime to 23.08

### DIFF
--- a/org.squeakland.Etoys.json
+++ b/org.squeakland.Etoys.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.squeakland.Etoys",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "20.08",
+  "runtime-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "etoys",
   "finish-args": [


### PR DESCRIPTION
Updating the runtime so that this software is no longer EOL, and will hopefully allow more people to use it in the future.